### PR TITLE
Memory friendly

### DIFF
--- a/library/src/main/java/eightbitlab/com/blurview/BlurAlgorithm.java
+++ b/library/src/main/java/eightbitlab/com/blurview/BlurAlgorithm.java
@@ -1,10 +1,11 @@
 package eightbitlab.com.blurview;
 
 import android.graphics.Bitmap;
+import android.support.annotation.NonNull;
 
 public interface BlurAlgorithm {
     /**
-     * @param bitmap bitmap to be blurred
+     * @param bitmap     bitmap to be blurred
      * @param blurRadius blur radius
      * @return blurred bitmap
      */
@@ -19,4 +20,13 @@ public interface BlurAlgorithm {
      * @return true if sent bitmap can be modified, false otherwise
      */
     boolean canModifyBitmap();
+
+    /**
+     * Retrieve the {@link android.graphics.Bitmap.Config} on which the {@link BlurAlgorithm}
+     * can actually work.
+     *
+     * @return bitmap config supported by the given blur algorithm.
+     */
+    @NonNull
+    Bitmap.Config getSupportedBitmapConfig();
 }

--- a/library/src/main/java/eightbitlab/com/blurview/DefaultBlurController.java
+++ b/library/src/main/java/eightbitlab/com/blurview/DefaultBlurController.java
@@ -170,7 +170,7 @@ class DefaultBlurController implements BlurController {
         roundingHeightScaleFactor = (float) scaledHeight / nonRoundedScaledHeight;
         roundingWidthScaleFactor = (float) scaledWidth / nonRoundedScaledWidth;
 
-        internalBitmap = Bitmap.createBitmap(scaledWidth, scaledHeight, Bitmap.Config.ARGB_8888);
+        internalBitmap = Bitmap.createBitmap(scaledWidth, scaledHeight, blurAlgorithm.getSupportedBitmapConfig());
     }
 
     //draw starting from blurView's position

--- a/library/src/main/java/eightbitlab/com/blurview/RenderScriptBlur.java
+++ b/library/src/main/java/eightbitlab/com/blurview/RenderScriptBlur.java
@@ -2,6 +2,7 @@ package eightbitlab.com.blurview;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.support.annotation.NonNull;
 import android.support.v8.renderscript.Allocation;
 import android.support.v8.renderscript.Element;
 import android.support.v8.renderscript.RenderScript;
@@ -23,7 +24,7 @@ public final class RenderScriptBlur implements BlurAlgorithm {
     }
 
     /**
-     * @param bitmap bitmap to blur
+     * @param bitmap     bitmap to blur
      * @param blurRadius blur radius (1..25)
      * @return blurred bitmap
      */
@@ -37,7 +38,7 @@ public final class RenderScriptBlur implements BlurAlgorithm {
         } else {
             outputBitmap = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), bitmap.getConfig());
         }
-        
+
         //do not use inAllocation in forEach. it will cause visual artifacts on blurred Bitmap
         Allocation outAllocation = Allocation.createTyped(renderScript, inAllocation.getType());
 
@@ -60,5 +61,11 @@ public final class RenderScriptBlur implements BlurAlgorithm {
     @Override
     public boolean canModifyBitmap() {
         return canModifyBitmap;
+    }
+
+    @NonNull
+    @Override
+    public Bitmap.Config getSupportedBitmapConfig() {
+        return Bitmap.Config.ARGB_8888;
     }
 }

--- a/library/src/main/java/eightbitlab/com/blurview/StackBlur.java
+++ b/library/src/main/java/eightbitlab/com/blurview/StackBlur.java
@@ -54,12 +54,9 @@ public final class StackBlur implements BlurAlgorithm {
 
         int wm = w - 1;
         int hm = h - 1;
-        int wh = w * h;
         int div = radius + radius + 1;
 
-        int r[] = new int[wh];
-        int g[] = new int[wh];
-        int b[] = new int[wh];
+        int px = 0;
         int rsum, gsum, bsum, x, y, i, p, yp, yi, yw;
         int vmin[] = new int[Math.max(w, h)];
 
@@ -107,9 +104,7 @@ public final class StackBlur implements BlurAlgorithm {
 
             for (x = 0; x < w; x++) {
 
-                r[yi] = dv[rsum];
-                g[yi] = dv[gsum];
-                b[yi] = dv[bsum];
+                pix[yi] = (0xff000000 & pix[yi]) | (dv[rsum] << 16) | (dv[gsum] << 8) | dv[bsum];
 
                 rsum -= routsum;
                 gsum -= goutsum;
@@ -125,6 +120,7 @@ public final class StackBlur implements BlurAlgorithm {
                 if (y == 0) {
                     vmin[x] = Math.min(x + radius + 1, wm);
                 }
+
                 p = pix[yw + vmin[x]];
 
                 sir[0] = (p & 0xff0000) >> 16;
@@ -162,15 +158,17 @@ public final class StackBlur implements BlurAlgorithm {
 
                 sir = stack[i + radius];
 
-                sir[0] = r[yi];
-                sir[1] = g[yi];
-                sir[2] = b[yi];
+                px = pix[yi];
+
+                sir[0] = (px & 0xff0000) >> 16;
+                sir[1] = (px & 0x00ff00) >> 8;
+                sir[2] = (px & 0x0000ff);
 
                 rbs = r1 - Math.abs(i);
 
-                rsum += r[yi] * rbs;
-                gsum += g[yi] * rbs;
-                bsum += b[yi] * rbs;
+                rsum += sir[0] * rbs;
+                gsum += sir[1] * rbs;
+                bsum += sir[2] * rbs;
 
                 if (i > 0) {
                     rinsum += sir[0];
@@ -208,9 +206,11 @@ public final class StackBlur implements BlurAlgorithm {
                 }
                 p = x + vmin[y];
 
-                sir[0] = r[p];
-                sir[1] = g[p];
-                sir[2] = b[p];
+                px = pix[p];
+
+                sir[0] = (px & 0xff0000) >> 16;
+                sir[1] = (px & 0x00ff00) >> 8;
+                sir[2] = (px & 0x0000ff);
 
                 rinsum += sir[0];
                 ginsum += sir[1];

--- a/library/src/main/java/eightbitlab/com/blurview/StackBlur.java
+++ b/library/src/main/java/eightbitlab/com/blurview/StackBlur.java
@@ -12,9 +12,13 @@ import android.support.annotation.NonNull;
  */
 public final class StackBlur implements BlurAlgorithm {
     private boolean canReuseInBitmap;
+    private int[] pix;
+    private int[] dv;
 
     public StackBlur(boolean canReuseInBitmap) {
         this.canReuseInBitmap = canReuseInBitmap;
+        pix = new int[1];
+        dv = new int[1];
     }
 
     @Override
@@ -49,7 +53,9 @@ public final class StackBlur implements BlurAlgorithm {
         int w = bitmap.getWidth();
         int h = bitmap.getHeight();
 
-        int[] pix = new int[w * h];
+        if (pix.length != w * h) {
+            pix = new int[w * h];
+        }
         bitmap.getPixels(pix, 0, w, 0, 0, w, h);
 
         int wm = w - 1;
@@ -62,7 +68,9 @@ public final class StackBlur implements BlurAlgorithm {
 
         int divsum = (div + 1) >> 1;
         divsum *= divsum;
-        int dv[] = new int[256 * divsum];
+        if (dv.length != 256 * divsum) {
+            dv = new int[256 * divsum];
+        }
         for (i = 0; i < 256 * divsum; i++) {
             dv[i] = (i / divsum);
         }
@@ -242,6 +250,8 @@ public final class StackBlur implements BlurAlgorithm {
 
     @Override
     public void destroy() {
+        pix = null;
+        dv = null;
     }
 
     @Override

--- a/library/src/main/java/eightbitlab/com/blurview/StackBlur.java
+++ b/library/src/main/java/eightbitlab/com/blurview/StackBlur.java
@@ -1,6 +1,7 @@
 package eightbitlab.com.blurview;
 
 import android.graphics.Bitmap;
+import android.support.annotation.NonNull;
 
 /**
  * @author Mario Klingemann
@@ -240,10 +241,17 @@ public final class StackBlur implements BlurAlgorithm {
     }
 
     @Override
-    public void destroy() {}
+    public void destroy() {
+    }
 
     @Override
     public boolean canModifyBitmap() {
         return canReuseInBitmap;
+    }
+
+    @NonNull
+    @Override
+    public Bitmap.Config getSupportedBitmapConfig() {
+        return Bitmap.Config.RGB_565;
     }
 }


### PR DESCRIPTION
Hi and welcome to the blur world (=

Here are some improvements regarding the memory footprint of the stack blur : 
- using RGB_565 seems to be enough when it comes to blur an image and it cuts the allocation of your original bitmap by half ([Unfortunately RenderScript can't work on this config](http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.4_r1/android/support/v8/renderscript/ScriptIntrinsicBlur.java#53)).
- using a single temp array and some bit shifts avoids allocating 3 temp array for each channel R,G and B.
- caching the temp array used for the blur avoids new allocation for each frame and cuts considerably the allocation for the same blurred view.


Here is a small overview of the benefit of such small tweaks when you spam scrolling on the tab1 of your demo app: 

current master 
<img width="1440" alt="screen shot 2016-06-12 at 11 16 00" src="https://cloud.githubusercontent.com/assets/4211470/15990354/8dcb59d6-3090-11e6-810d-45e68c2c172b.png">

with memory tweaks
<img width="1440" alt="screen shot 2016-06-12 at 11 40 31" src="https://cloud.githubusercontent.com/assets/4211470/15990436/7fcf0b3c-3092-11e6-933f-09e244a08b8d.png">


Don't hesitate to check previous works on blur effect for Android to take advantage of it (:

Thomas.



