### PR TITLE
Update manifest to remove unnecessary attributes

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="eightbitlab.com.blurview">
 
-    <application android:allowBackup="true"
-                 android:supportsRtl="true">
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Remove android:allowBackup="true"
Remove android:supportsRtl="true"
These attributes are unnecessary in a library and will potentially cause builds to fail