### PR TITLE
Fix: Intermittent IllegalStateException

### DIFF
--- a/library/src/main/java/eightbitlab/com/blurview/RenderEffectBlur.java
+++ b/library/src/main/java/eightbitlab/com/blurview/RenderEffectBlur.java
@@ -43,6 +43,9 @@ public class RenderEffectBlur implements BlurAlgorithm {
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         blurView.getMeasuredHeight()
                 );
+                if (backgroundView.getParent() != null) {
+                    ((ViewGroup)backgroundView.getParent()).removeView(backgroundView);
+                }
                 blurView.addView(backgroundView, 0, params);
             }
         });


### PR DESCRIPTION
Guard against IllegalStateException caused by adding backgroundView to blurView when it already has a parent. This seems to be an intermittent problem I picked up from Crashlytics.