### PR TITLE
Don't crash during updateBlur() if `viewRoot` call save() and restore() an unequal amount of times (Fix #184)

### DIFF
--- a/library/src/main/java/eightbitlab/com/blurview/BlurViewCanvas.java
+++ b/library/src/main/java/eightbitlab/com/blurview/BlurViewCanvas.java
@@ -19,10 +19,21 @@ public class BlurViewCanvas extends Canvas {
         super(bitmap);
     }
 
-    public void saveRoot() {
+    /**
+     * Call normal {@link Canvas#save()} to save current index to
+     * {@link #saveCountInitial}, should only be called by
+     * {@link PreDrawBlurController#updateBlur()}
+     */
+    void saveRoot() {
         saveCountInitial = this.save();
     }
 
+    /**
+     * Override of {@link Canvas#restore()} to avoid
+     * crashed when there is more restores than saves,
+     * use {@link #saveCountInitial} to count save/restore count
+     * so there is no need to override or hook {@link Canvas#save()}
+     */
     @Override
     public void restore() {
         if (getSaveCount() <= saveCountInitial) {
@@ -33,12 +44,22 @@ public class BlurViewCanvas extends Canvas {
         super.restore();
     }
 
+    /**
+     * Override of {@link Canvas#restoreToCount(int)} to avoid
+     * restoring to the original transformation matrix.
+     *
+     * @param saveCount The save level to restore to.
+     */
     @Override
     public void restoreToCount(int saveCount) {
         super.restoreToCount(Math.max(saveCount, saveCountInitial));
     }
 
-    public void restoreRoot() {
+    /**
+     * Restore to {@link #saveCountInitial}, should
+     * only be called by {@link PreDrawBlurController#updateBlur()}
+     */
+    void restoreRoot() {
         if (getSaveCount() > saveCountInitial + 1) {
             Log.e("BlurView", "rootView has more saves than restores");
         }

--- a/library/src/main/java/eightbitlab/com/blurview/BlurViewCanvas.java
+++ b/library/src/main/java/eightbitlab/com/blurview/BlurViewCanvas.java
@@ -2,13 +2,47 @@ package eightbitlab.com.blurview;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-// Servers purely as a marker of a Canvas used in BlurView
-// to skip drawing itself and other BlurViews on the View hierarchy snapshot
+/** Servers as a marker of a Canvas used in BlurView to skip drawing
+ * itself and other BlurViews on the View hierarchy snapshot
+ *
+ * Also used to avoid BlurView crashing when the {@code rootView} call
+ * {@link Canvas#save()} and {@link Canvas#restore()} an unequal amount of times.
+ * */
 public class BlurViewCanvas extends Canvas {
+    private int saveCountInitial;
+
     public BlurViewCanvas(@NonNull Bitmap bitmap) {
         super(bitmap);
+    }
+
+    public void saveRoot() {
+        saveCountInitial = this.save();
+    }
+
+    @Override
+    public void restore() {
+        if (getSaveCount() <= saveCountInitial) {
+            Log.e("BlurView", "rootView has more restores than saves",
+                    new IllegalStateException("Underflow in restore - more restores than saves"));
+            return;
+        }
+        super.restore();
+    }
+
+    @Override
+    public void restoreToCount(int saveCount) {
+        super.restoreToCount(Math.max(saveCount, saveCountInitial));
+    }
+
+    public void restoreRoot() {
+        if (getSaveCount() > saveCountInitial + 1) {
+            Log.e("BlurView", "rootView has more saves than restores");
+        }
+        super.restoreToCount(saveCountInitial);
+        saveCountInitial = 0;
     }
 }

--- a/library/src/main/java/eightbitlab/com/blurview/PreDrawBlurController.java
+++ b/library/src/main/java/eightbitlab/com/blurview/PreDrawBlurController.java
@@ -110,10 +110,13 @@ final class PreDrawBlurController implements BlurController {
             frameClearDrawable.draw(internalCanvas);
         }
 
-        internalCanvas.save();
-        setupInternalCanvasMatrix();
-        rootView.draw(internalCanvas);
-        internalCanvas.restore();
+        internalCanvas.saveRoot();
+        try {
+            setupInternalCanvasMatrix();
+            rootView.draw(internalCanvas);
+        } finally {
+            internalCanvas.restoreRoot();
+        }
 
         blurAndSave();
     }


### PR DESCRIPTION
This match the behavior of `sCompatibilityRestore` for app targeting android 5.1 (sdk 22) and earlier.

Reference: [Canvas.java](https://github.com/LineageOS/android_frameworks_base/blob/lineage-19.1/graphics/java/android/graphics/Canvas.java) from LineageOS 19.1 (Other ROMs should be the same)

This will also help to avoid being mislead that BlurView is the cause of issues that BlurView has nothing to do with.

I also updated the javadoc on `BlurViewCanvas`