### PR TITLE
Bring back old setupWith method and allow null `BlurAlgorithm`

### DIFF
--- a/library/src/main/java/eightbitlab/com/blurview/NoOpController.java
+++ b/library/src/main/java/eightbitlab/com/blurview/NoOpController.java
@@ -7,6 +7,10 @@ import androidx.annotation.Nullable;
 
 //Used in edit mode and in case if no BlurController was set
 class NoOpController implements BlurController {
+    static final NoOpController INSTANCE = new NoOpController();
+
+    private NoOpController() {}
+
     @Override
     public boolean draw(Canvas canvas) {
         return true;


### PR DESCRIPTION
I recently upgraded from `1.6.6` to `2.0.2` and I noticed setupWith method signature changed.

Bring back the old setupWith by choosing best available algorithm with of few thing I would like as a developer.

Also only using one instance of `NoOpController` instead of making one for each `BlurView`.