### PR TITLE
(fix)`setBlurAutoUpdate` not persisting between window mount cycles.

### DIFF
--- a/library/src/main/java/eightbitlab/com/blurview/BlurView.java
+++ b/library/src/main/java/eightbitlab/com/blurview/BlurView.java
@@ -27,6 +27,7 @@ public class BlurView extends FrameLayout {
 
     @ColorInt
     private int overlayColor;
+    private boolean blurAutoUpdate = true;
 
     public BlurView(Context context) {
         super(context);
@@ -75,7 +76,7 @@ public class BlurView extends FrameLayout {
         if (!isHardwareAccelerated()) {
             Log.e(TAG, "BlurView can't be used in not hardware-accelerated window!");
         } else {
-            blurController.setBlurAutoUpdate(true);
+            blurController.setBlurAutoUpdate(this.blurAutoUpdate);
         }
     }
 
@@ -129,6 +130,7 @@ public class BlurView extends FrameLayout {
      * @see BlurViewFacade#setBlurAutoUpdate(boolean)
      */
     public BlurViewFacade setBlurAutoUpdate(boolean enabled) {
+        this.blurAutoUpdate = enabled;
         return blurController.setBlurAutoUpdate(enabled);
     }
 


### PR DESCRIPTION
# Why
After calling `setBlurAutoUpdate(false)` on a `BlurView` the updates will be paused, but will resume after the view is re-attached. 

# How
Save the `enabled` parameter into a variable and restore it's value after the view is re-mounted

### Test Plan

Tested this in my app and seems to 