### PR TITLE
Make it possible to use and create a custom `BlurController`

### DIFF
--- a/library/src/main/java/eightbitlab/com/blurview/BlurView.java
+++ b/library/src/main/java/eightbitlab/com/blurview/BlurView.java
@@ -23,7 +23,7 @@ public class BlurView extends FrameLayout {
 
     private static final String TAG = BlurView.class.getSimpleName();
 
-    BlurController blurController = new NoOpController();
+    protected BlurController blurController = new NoOpController();
 
     @ColorInt
     private int overlayColor;
@@ -80,6 +80,16 @@ public class BlurView extends FrameLayout {
     }
 
     /**
+     * @param blurController controller to handle blur drawing
+     * @return {@link BlurView} to setup needed params.
+     */
+    public BlurViewFacade setupWith(@NonNull BlurController blurController) {
+        this.blurController.destroy();
+        this.blurController = blurController;
+        return blurController;
+    }
+
+    /**
      * @param rootView  root to start blur from.
      *                  Can be Activity's root content layout (android.R.id.content)
      *                  or (preferably) some of your layouts. The lower amount of Views are in the root, the better for performance.
@@ -87,11 +97,9 @@ public class BlurView extends FrameLayout {
      * @return {@link BlurView} to setup needed params.
      */
     public BlurViewFacade setupWith(@NonNull ViewGroup rootView, BlurAlgorithm algorithm) {
-        this.blurController.destroy();
         BlurController blurController = new PreDrawBlurController(this, rootView, overlayColor, algorithm);
-        this.blurController = blurController;
 
-        return blurController;
+        return setupWith(blurController);
     }
 
     /**

--- a/library/src/main/java/eightbitlab/com/blurview/PreDrawBlurController.java
+++ b/library/src/main/java/eightbitlab/com/blurview/PreDrawBlurController.java
@@ -23,21 +23,21 @@ import androidx.annotation.Nullable;
  * blur should be updated.
  * <p>
  */
-public final class PreDrawBlurController implements BlurController {
+public class PreDrawBlurController implements BlurController {
 
     @ColorInt
     public static final int TRANSPARENT = 0;
 
     private float blurRadius = DEFAULT_BLUR_RADIUS;
 
-    private final BlurAlgorithm blurAlgorithm;
-    private BlurViewCanvas internalCanvas;
-    private Bitmap internalBitmap;
+    protected final BlurAlgorithm blurAlgorithm;
+    protected BlurViewCanvas internalCanvas;
+    protected Bitmap internalBitmap;
 
     @SuppressWarnings("WeakerAccess")
-    final View blurView;
-    private int overlayColor;
-    private final ViewGroup rootView;
+    protected final View blurView;
+    protected int overlayColor;
+    protected final ViewGroup rootView;
     private final int[] rootLocation = new int[2];
     private final int[] blurViewLocation = new int[2];
 
@@ -104,7 +104,7 @@ public final class PreDrawBlurController implements BlurController {
     }
 
     @SuppressWarnings("WeakerAccess")
-    void updateBlur() {
+    protected void updateBlur() {
         if (!blurEnabled || !initialized) {
             return;
         }
@@ -169,7 +169,7 @@ public final class PreDrawBlurController implements BlurController {
         return true;
     }
 
-    private void blurAndSave() {
+    protected void blurAndSave() {
         internalBitmap = blurAlgorithm.blur(internalBitmap, blurRadius);
         if (!blurAlgorithm.canModifyBitmap()) {
             internalCanvas.setBitmap(internalBitmap);

--- a/library/src/main/java/eightbitlab/com/blurview/RenderEffectBlur.java
+++ b/library/src/main/java/eightbitlab/com/blurview/RenderEffectBlur.java
@@ -88,7 +88,7 @@ public class RenderEffectBlur implements BlurAlgorithm {
         }
     }
 
-    void setContext(@NonNull Context context) {
+    public void setContext(@NonNull Context context) {
         this.context = context;
     }
 }

--- a/library/src/main/java/eightbitlab/com/blurview/SizeScaler.java
+++ b/library/src/main/java/eightbitlab/com/blurview/SizeScaler.java
@@ -16,7 +16,7 @@ public class SizeScaler {
         this.scaleFactor = scaleFactor;
     }
 
-    Size scale(int width, int height) {
+    public Size scale(int width, int height) {
         int nonRoundedScaledWidth = downscaleSize(width);
         int scaledWidth = roundSize(nonRoundedScaledWidth);
         //Only width has to be aligned to ROUNDING_VALUE
@@ -27,7 +27,7 @@ public class SizeScaler {
         return new Size(scaledWidth, scaledHeight, roundingScaleFactor);
     }
 
-    boolean isZeroSized(int measuredWidth, int measuredHeight) {
+    public boolean isZeroSized(int measuredWidth, int measuredHeight) {
         return downscaleSize(measuredHeight) == 0 || downscaleSize(measuredWidth) == 0;
     }
 
@@ -45,7 +45,7 @@ public class SizeScaler {
         return (int) Math.ceil(value / scaleFactor);
     }
 
-    static class Size {
+    public static class Size {
 
         final int width;
         final int height;
@@ -56,6 +56,14 @@ public class SizeScaler {
             this.width = width;
             this.height = height;
             this.scaleFactor = scaleFactor;
+        }
+
+        public int getWidth() {
+            return width;
+        }
+
+        public int getHeight() {
+            return height;
         }
 
         @Override


### PR DESCRIPTION
# Why
Hi!
In `expo-blur` we would like to create our own version of `PreDrawBlurController` unfortunately a lot of stuff has been made package private.  Making it impossible to do without creating a fork of the library. 

# How
I've split the PR into three commits:

- Allow setting up with a custom blur controller - Adds one more constructor to the BlurView, which accepts the desired blur controller. I also changed the other constructors to use it, and made the blurController protected so that views, which extend the `BlurView` can access it.

- Expose methods necessary for custom BlurControllers - The idea was to make it possible to copy contents of `PreDrawBlurController` into another package and still have it working. This mostly requires changes in the `SizeScaler` class where a lot of the methods were package private, and making the `setContext` method of the `RenderEffectBlur` public.

- Make it possible to extend `PreDrawBlurController` - I'm not sure if you will be ok with these changes, we can manage without them, but it would be quite a bit easier for us if we could extend `PreDrawBlurController`. Makes the class non-final and changes the access of some variables and methods to `protected` so inheriting classes have access to them.

The first two commits would be necessary for us to do what we want, the third one is nice to have. 
Can you let me know if you would be ok with those changes?

# Test Plan

Tested in the included test app and our react-native library.

